### PR TITLE
Fixed bugs in test case

### DIFF
--- a/test/common/provision.go
+++ b/test/common/provision.go
@@ -41,9 +41,11 @@ func TestProvision(
 
 		if async {
 			Convey("should return 422 UnprocessableEntity if missing accepts_incomplete", func() {
+				tempBody := openapi.ServiceInstanceProvisionRequest{}
+				deepCopy(req, &tempBody)
 				_, resp, err := cli.ServiceInstancesApi.ServiceInstanceProvision(
-					authCtx, CONF.APIVersion, instanceID, openapi.ServiceInstanceProvisionRequest{},
-					&openapi.ServiceInstanceProvisionOpts{AcceptsIncomplete: optional.NewBool(false)})
+					authCtx, CONF.APIVersion, instanceID, tempBody,
+					&openapi.ServiceInstanceProvisionOpts{})
 
 				So(err, ShouldNotBeNil)
 				So(resp.StatusCode, ShouldEqual, 422)


### PR DESCRIPTION
When provisioning an instance it is required to have service_id and plan_id to be non-empty values. This test case was missing this, which caused it to fail no matter what. This has been fixed now.