### PR TITLE
Switch case was missing planID for case unbind

### DIFF
--- a/test/lifecycle_test.go
+++ b/test/lifecycle_test.go
@@ -85,6 +85,7 @@ func TestLifeCycle(t *testing.T) {
 				common.TestGetBinding(t, instanceID, bindingID)
 				break
 			case "unbind":
+				currentPlanID = operation.PlanID
 				common.TestUnbind(t, instanceID, bindingID, serviceID, currentPlanID, operation.Async)
 				break
 			default:


### PR DESCRIPTION
Added missing currentPlanID to case "unbind" in life_cycle.go. It remained an empty string throughout the tests, which caused some of them to fail.