### PR TITLE
Testfix binding

### DIFF
--- a/test/common/bind.go
+++ b/test/common/bind.go
@@ -41,8 +41,10 @@ func TestBind(
 
 		if async {
 			Convey("should return 422 UnprocessableEntity if missing accepts_incomplete", func() {
+				tempBody := openapi.ServiceBindingRequest{}
+				deepCopy(req, &tempBody)
 				_, resp, err := cli.ServiceBindingsApi.ServiceBindingBinding(
-					authCtx, CONF.APIVersion, instanceID, bindingID, openapi.ServiceBindingRequest{},
+					authCtx, CONF.APIVersion, instanceID, bindingID, tempBody,
 					&openapi.ServiceBindingBindingOpts{AcceptsIncomplete: optional.NewBool(false)})
 
 				So(err, ShouldNotBeNil)

--- a/test/lifecycle_test.go
+++ b/test/lifecycle_test.go
@@ -73,6 +73,8 @@ func TestLifeCycle(t *testing.T) {
 				common.TestDeprovision(t, instanceID, serviceID, currentPlanID, operation.Async)
 				break
 			case "bind":
+				currentPlanID = operation.PlanID
+
 				req := &openapi.ServiceBindingRequest{
 					ServiceId:  serviceID,
 					PlanId:     currentPlanID,


### PR DESCRIPTION
Fixed bug with binding. Missing parameters which are service_id and plan_id. Both of these parameters are required and must be included in the body of the request.

I also added missing currentPlanID to case "bind" in life_cycle.go. It remained an empty string throughout the tests, which caused some of them to fail.